### PR TITLE
Several fixes for button management and eyetracking calibration in th…

### DIFF
--- a/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/API/EyeTrackerAPI.cs
+++ b/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/API/EyeTrackerAPI.cs
@@ -106,6 +106,7 @@ namespace AdhawkApi
             udpClient.RegisterOnConnect(() => {
                 Streams.Gaze.Start();
                 Events.Blink.Start();
+                Streams.TrackerReady.Start();
                 SetLogMode(AdHawkAnalyticsLogMode);
             });
 
@@ -124,6 +125,7 @@ namespace AdhawkApi
             Streams.GlintXY.AddListener((data) => HandleGlint((GlintDataStruct)data));
             Streams.PupilXY.AddListener((data) => HandlePupilXY((PupilXYStruct)data));
             Streams.PupilXY.AddListener((data) => HandleFuse((FuseDataStruct)data));
+            Streams.TrackerReady.AddListener((data) => HandleTrackerReady((TrackerReadyStruct)data));
         }
 
         private void OnDestroy()

--- a/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/API/StreamHandler/AHStreamHandler.cs
+++ b/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/API/StreamHandler/AHStreamHandler.cs
@@ -21,6 +21,7 @@ namespace AdhawkApi
             IMU = new IMURotationStream(udpClient);
             PulseXY = new PulseDataStream(udpClient);
             TrackerStatus = new TrackerStatusStream(udpClient);
+            TrackerReady = new TrackerReadyStream(udpClient);
         }
         public GazeStream Gaze;
         public GazeInScreenStream GazeInScreen;
@@ -35,5 +36,6 @@ namespace AdhawkApi
         public IMURotationStream IMU;
         public PulseDataStream PulseXY;
         public TrackerStatusStream TrackerStatus;
+        public TrackerReadyStream TrackerReady;
     }
 }

--- a/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/API/StreamHandler/Streams/TrackerReadyStream.cs
+++ b/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/API/StreamHandler/Streams/TrackerReadyStream.cs
@@ -7,20 +7,17 @@ using UnityEngine;
 
 namespace AdhawkApi
 {
-    public struct TrackerStatusStruct : PacketDataStruct
+    public struct TrackerReadyStruct : PacketDataStruct
     {
         //status,
-        public TrackerStatusStruct(byte[] data)
+        public TrackerReadyStruct(byte[] data)
         {
-            int i = 0;
-            data.ReadNextInt8(ref i, out TrackerStatus);
         }
-        public byte TrackerStatus;
     }
-    public class TrackerStatusStream : AHTrackingStream<TrackerStatusStruct>
+    public class TrackerReadyStream : AHTrackingStream<TrackerReadyStruct>
     {
-        public TrackerStatusStream(UDPBehaviour udpClient) : base(udpClient) { }
-        public override byte StreamPacketByte { get { return 0x16; } }
+        public TrackerReadyStream(UDPBehaviour udpClient) : base(udpClient) { }
+        public override byte StreamPacketByte { get { return 0x02; } }
 
         public override udpInfo.StreamControl StreamControlBit { get { return 0; } }
 

--- a/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/API/StreamHandler/Streams/TrackerReadyStream.cs.meta
+++ b/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/API/StreamHandler/Streams/TrackerReadyStream.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4c24ee66e9009447bdad7d265ae3e19
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/API/etapi_ahapi_requests.cs
+++ b/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/API/etapi_ahapi_requests.cs
@@ -565,6 +565,7 @@ namespace AdhawkApi
         }
         private IEnumerator RequestAutotuneCoroutine(float timeout = 4.0f)
         {
+            double curLastTrackerReadyTime = lastTrackerReadySignalTime;
             Debug.Log("Requesting autotune");
             if (RunningAutotune)
             {
@@ -593,6 +594,24 @@ namespace AdhawkApi
                 timeout: timeout
             );
             Debug.Log("Autotune request sent.");
+            float time_waited = 0;
+            float tracker_ready_timeout = 8.0f;
+            yield return new WaitUntil(() =>
+            {
+                time_waited += Time.deltaTime;
+                if (time_waited > tracker_ready_timeout)
+                {
+                    Debug.LogError("Timeout when waiting for tracker ready signal");
+                    return true;
+                } 
+                if (curLastTrackerReadyTime != lastTrackerReadySignalTime)
+                {
+                    Debug.Log("Tracker ready signal recieved, autotune complete.");
+                    return true;
+                }
+                return false;
+            });
+
             RunningAutotune = false;
         }
 

--- a/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/API/etapi_private.cs
+++ b/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/API/etapi_private.cs
@@ -18,6 +18,8 @@ namespace AdhawkApi
 
         private SystemErrorHandler ErrorCallback;
 
+        private double lastTrackerReadySignalTime = 0;
+
         private Camera _maincam;
         private Camera MainCam
         {
@@ -55,6 +57,12 @@ namespace AdhawkApi
         private void HandlePupilXY(PupilXYStruct pupilxyData)
         {
             PupilPositions[pupilxyData.TrackerId] = pupilxyData.Position;
+        }
+
+        private void HandleTrackerReady(TrackerReadyStruct data)
+        {
+            Debug.Log("Tracker ready recieved");
+            lastTrackerReadySignalTime = Time.time;
         }
 
         private void HandleBlink(BlinkDataStruct blinkData)

--- a/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/Tools/Player.cs
+++ b/Assets/EyeTrackingAPI/Runtime/Scripts/EyeTrackerAPI/Tools/Player.cs
@@ -49,7 +49,7 @@ namespace AdhawkApi
 
             if (EyeCenter == null)
             {
-                EyeCenter = transform;
+                EyeCenter = Camera.main.transform;
             }
             if (Cam == null)
             {

--- a/Assets/Scenes/2 Calibration Scene.unity
+++ b/Assets/Scenes/2 Calibration Scene.unity
@@ -199,11 +199,11 @@ MonoBehaviour:
 
 
     Please begin
-    by staring at the center target
+    by staring at the center target until the target animates.
 
 
-    Press the triggers on your controller to
-    begin calibration.'
+    Press the triggers
+    on your controller to begin calibration.'
 --- !u!222 &78610951
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -212,6 +212,56 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 78610948}
   m_CullTransparentMesh: 1
+--- !u!1 &329356556
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 329356558}
+  - component: {fileID: 329356557}
+  m_Layer: 0
+  m_Name: instruction_holder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &329356557
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 329356556}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a2a9c34df4095f47b9ca8f975175f5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Device: 0
+  m_PoseSource: 2
+  m_PoseProviderComponent: {fileID: 0}
+  m_TrackingType: 0
+  m_UpdateType: 0
+  m_UseRelativeTransform: 0
+--- !u!4 &329356558
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 329356556}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.36144, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 448134397}
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &448134396
 GameObject:
   m_ObjectHideFlags: 0
@@ -238,20 +288,20 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 448134396}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.654}
+  m_LocalScale: {x: 0.0010691672, y: 0.0010691672, z: 0.0010691672}
   m_Children:
   - {fileID: 1241337623}
   - {fileID: 78610949}
-  m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_Father: {fileID: 329356558}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
+  m_SizeDelta: {x: 1920, y: 1080}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &448134398
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -291,7 +341,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!223 &448134400
 Canvas:
   m_ObjectHideFlags: 0
@@ -301,7 +351,7 @@ Canvas:
   m_GameObject: {fileID: 448134396}
   m_Enabled: 1
   serializedVersion: 3
-  m_RenderMode: 1
+  m_RenderMode: 2
   m_Camera: {fileID: 963194227}
   m_PlaneDistance: 1
   m_PixelPerfect: 0
@@ -750,6 +800,49 @@ MonoBehaviour:
   m_TrackingType: 0
   m_UpdateType: 0
   m_UseRelativeTransform: 0
+--- !u!1 &982715008
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 982715010}
+  - component: {fileID: 982715009}
+  m_Layer: 0
+  m_Name: InputDebugger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &982715009
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982715008}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e68939312246cc4f842e61b7d1b9f22, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &982715010
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982715008}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.12962689, y: 1.3593746, z: 0.4709246}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1007493329
 GameObject:
   m_ObjectHideFlags: 0
@@ -779,7 +872,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1007493331
 MonoBehaviour:
@@ -1186,51 +1279,8 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1806978669
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1806978670}
-  - component: {fileID: 1806978671}
-  m_Layer: 0
-  m_Name: Controller input handling
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1806978670
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1806978669}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.2558231, y: 1.0876083, z: 0.08237703}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1806978671
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1806978669}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bcd2e11debf58ac44a730d03247df96b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1930371928
 GameObject:
   m_ObjectHideFlags: 0
@@ -1295,7 +1345,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1949593302
 PrefabInstance:


### PR DESCRIPTION
Several fixes for button management and eyetracking calibration errors in the calibration scene

- fixed button double-pressing during calibration in some cases
- fixed calibration so first center point will auto-trigger after autotune is fully completed
- added tracker ready stream to handle autotune complete wait
- fixed a bug with Player.cs for VR if camera objects are not already assigned